### PR TITLE
Use go1.10.1 and go1.9.5

### DIFF
--- a/1.10/Makefile.COMMON
+++ b/1.10/Makefile.COMMON
@@ -15,7 +15,7 @@ REPOSITORY    := quay.io/prometheus
 NAME          := golang-builder
 BRANCH        := $(shell git rev-parse --abbrev-ref HEAD)
 SUFFIX        ?= -$(subst /,-,$(BRANCH))
-VERSION       := 1.10.0
+VERSION       := 1.10.1
 DIRNAME       := $(shell basename $(CURDIR))
 PARENTDIRNAME := $(shell basename $(shell dirname $(CURDIR)))
 

--- a/1.10/base/Dockerfile
+++ b/1.10/base/Dockerfile
@@ -12,9 +12,9 @@ RUN \
         make \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.10
+ENV GOLANG_VERSION 1.10.1
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33
+ENV GOLANG_DOWNLOAD_SHA256 72d820dec546752e5a8303b33b009079c15c2390ce76d67cf514991646c6127b
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/1.9/Makefile.COMMON
+++ b/1.9/Makefile.COMMON
@@ -15,7 +15,7 @@ REPOSITORY    := quay.io/prometheus
 NAME          := golang-builder
 BRANCH        := $(shell git rev-parse --abbrev-ref HEAD)
 SUFFIX        ?= -$(subst /,-,$(BRANCH))
-VERSION       := 1.9.4
+VERSION       := 1.9.5
 DIRNAME       := $(shell basename $(CURDIR))
 PARENTDIRNAME := $(shell basename $(shell dirname $(CURDIR)))
 

--- a/1.9/base/Dockerfile
+++ b/1.9/base/Dockerfile
@@ -12,9 +12,9 @@ RUN \
         make \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.9.4
+ENV GOLANG_VERSION 1.9.5
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 15b0937615809f87321a457bb1265f946f9f6e736c563d6c5e0bd2c22e44f779
+ENV GOLANG_DOWNLOAD_SHA256 d21bdabf4272c2248c41b45cec606844bdc5c7c04240899bde36c01a28c51ee7
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 
 Docker Builder Image for cross-building Golang Prometheus projects.
 
-- `latest`, `main`, `1.10-main`, `1.10.0-main` ([1.10/main/Dockerfile](1.10/main/Dockerfile))
-- `arm`, `1.10-arm`, `1.10.0-arm` ([1.10/arm/Dockerfile](1.10/arm/Dockerfile))
-- `powerpc`, `1.10-powerpc`, `1.10.0-powerpc` ([1.10/powerpc/Dockerfile](1.10/powerpc/Dockerfile))
-- `mips`, `1.10-mips`, `1.10.0-mips` ([1.10/mips/Dockerfile](1.10/mips/Dockerfile))
-- `1.9-main`, `1.9.4-main` ([1.9/main/Dockerfile](1.9/main/Dockerfile))
-- `1.9-arm`, `1.9.4-arm` ([1.9/arm/Dockerfile](1.9/arm/Dockerfile))
-- `1.9-powerpc`, `1.9.4-powerpc` ([1.9/powerpc/Dockerfile](1.9/powerpc/Dockerfile))
-- `1.9-mips`, `1.9.4-mips` ([1.9/mips/Dockerfile](1.9/mips/Dockerfile))
+- `latest`, `main`, `1.10-main`, `1.10.1-main` ([1.10/main/Dockerfile](1.10/main/Dockerfile))
+- `arm`, `1.10-arm`, `1.10.1-arm` ([1.10/arm/Dockerfile](1.10/arm/Dockerfile))
+- `powerpc`, `1.10-powerpc`, `1.10.1-powerpc` ([1.10/powerpc/Dockerfile](1.10/powerpc/Dockerfile))
+- `mips`, `1.10-mips`, `1.10.1-mips` ([1.10/mips/Dockerfile](1.10/mips/Dockerfile))
+- `1.9-main`, `1.9.5-main` ([1.9/main/Dockerfile](1.9/main/Dockerfile))
+- `1.9-arm`, `1.9.5-arm` ([1.9/arm/Dockerfile](1.9/arm/Dockerfile))
+- `1.9-powerpc`, `1.9.5-powerpc` ([1.9/powerpc/Dockerfile](1.9/powerpc/Dockerfile))
+- `1.9-mips`, `1.9.5-mips` ([1.9/mips/Dockerfile](1.9/mips/Dockerfile))
 
 ## Usage
 


### PR DESCRIPTION
The latest patch versions include two important fixes for the Prometheus
project:

* https://github.com/golang/go/issues/23995
* https://github.com/golang/go/issues/24059

@brian-brazil @sdurrheimer 

Needed for https://github.com/prometheus/prometheus/issues/3983 and https://github.com/prometheus/node_exporter/issues/870