### PR TITLE
Use debian:stable base image

### DIFF
--- a/1.10/base/Dockerfile
+++ b/1.10/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM        debian:sid
+FROM        debian:stable
 MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 
 RUN \

--- a/1.9/base/Dockerfile
+++ b/1.9/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM        debian:sid
+FROM        debian:stable
 MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 
 RUN \


### PR DESCRIPTION
We upgraded to sid[0] to get a newer gcc, but this was a long time ago,
and we get some compatibility issues with builds on the bleeding
edge[1].

Use Debian stable (stretch at this time) which includes GCC 6.3[2].  This
should be new enough.

Signed-off-by: Ben Kochie <bjk@gitlab.com>

[0]: https://github.com/prometheus/golang-builder/pull/2
[1]: https://github.com/prometheus/node_exporter/issues/914
[2]: https://packages.debian.org/stretch/gcc