### PR TITLE
Add missing package to mips build

### DIFF
--- a/1.10/mips/Dockerfile
+++ b/1.10/mips/Dockerfile
@@ -6,6 +6,7 @@ RUN \
         crossbuild-essential-mipsel \
         g++-mips-linux-gnu \
         gcc-mips-linux-gnu \
+        libc6-dev-mipsel-cross \
     && rm -rf /var/lib/apt/lists/*
 
 COPY rootfs /

--- a/1.9/mips/Dockerfile
+++ b/1.9/mips/Dockerfile
@@ -6,6 +6,7 @@ RUN \
         crossbuild-essential-mipsel \
         g++-mips-linux-gnu \
         gcc-mips-linux-gnu \
+        libc6-dev-mipsel-cross \
     && rm -rf /var/lib/apt/lists/*
 
 COPY rootfs /


### PR DESCRIPTION
Fix CGO build on MIPS due to missing `gnu/stubs-n64_hard.h` file.

Signed-off-by: Ben Kochie <superq@gmail.com>