### PR TITLE
Adding bzr to base Docker image

### DIFF
--- a/1.11/base/Dockerfile
+++ b/1.11/base/Dockerfile
@@ -9,6 +9,7 @@ RUN \
             ca-certificates \
             curl \
             git \
+            bzr \
             gnupg \
             libsnmp-dev \
             make \

--- a/1.12/base/Dockerfile
+++ b/1.12/base/Dockerfile
@@ -9,6 +9,7 @@ RUN \
             ca-certificates \
             curl \
             git \
+            bzr \
             gnupg \
             libsnmp-dev \
             make \


### PR DESCRIPTION
The Thanos project uses these builder images to cross build their project and
when switching to go mod a depedency on `bzr` has been added.

Change is in commit b4d233e6fe904c52a22948afea3c3002d894e5df