### PR TITLE
Bump to Go 1.11.8 and 1.12.3

### DIFF
--- a/1.11/Makefile.COMMON
+++ b/1.11/Makefile.COMMON
@@ -15,7 +15,7 @@ REPOSITORY    := quay.io/prometheus
 NAME          := golang-builder
 BRANCH        := $(shell git rev-parse --abbrev-ref HEAD)
 SUFFIX        ?= -$(subst /,-,$(BRANCH))
-VERSION       := 1.11.7
+VERSION       := 1.11.8
 DIRNAME       := $(shell basename $(CURDIR))
 PARENTDIRNAME := $(shell basename $(shell dirname $(CURDIR)))
 

--- a/1.11/base/Dockerfile
+++ b/1.11/base/Dockerfile
@@ -15,9 +15,9 @@ RUN \
             make \
         && rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.11.7
+ENV GOLANG_VERSION 1.11.8
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 db687814288b3b541c1754dfd4ecc2b8fd0d5e7995624945e3054a350ca573d8
+ENV GOLANG_DOWNLOAD_SHA256 e32ab1c934b747999d04e8a550b97f4647f8b1b43e152de5650d4476bfd1d2e1
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/1.12/Makefile.COMMON
+++ b/1.12/Makefile.COMMON
@@ -15,7 +15,7 @@ REPOSITORY    := quay.io/prometheus
 NAME          := golang-builder
 BRANCH        := $(shell git rev-parse --abbrev-ref HEAD)
 SUFFIX        ?= -$(subst /,-,$(BRANCH))
-VERSION       := 1.12.2
+VERSION       := 1.12.3
 DIRNAME       := $(shell basename $(CURDIR))
 PARENTDIRNAME := $(shell basename $(shell dirname $(CURDIR)))
 

--- a/1.12/base/Dockerfile
+++ b/1.12/base/Dockerfile
@@ -15,9 +15,9 @@ RUN \
             make \
         && rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.12.2
+ENV GOLANG_VERSION 1.12.3
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 f28c1fde8f293cc5c83ae8de76373cf76ae9306909564f54e0edcf140ce8fe3f
+ENV GOLANG_DOWNLOAD_SHA256 3924819eed16e55114f02d25d03e77c916ec40b7fd15c8acb5838b63135b03df
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 
 Docker Builder Image for cross-building Golang Prometheus projects.
 
-- `latest`, `main`, `1.12-main`, `1.12.2-main` ([1.12/main/Dockerfile](1.12/main/Dockerfile))
-- `arm`, `1.12-arm`, `1.12.2-arm` ([1.12/arm/Dockerfile](1.12/arm/Dockerfile))
-- `powerpc`, `1.12-powerpc`, `1.12.2-powerpc` ([1.12/powerpc/Dockerfile](1.12/powerpc/Dockerfile))
-- `mips`, `1.12-mips`, `1.12.2-mips` ([1.12/mips/Dockerfile](1.12/mips/Dockerfile))
-- `s390x`, `1.12-s390x`, `1.12.2-s390x` ([1.12/s390x/Dockerfile](1.12/s390x/Dockerfile))
-- `1.11-main`, `1.11.7-main` ([1.11/main/Dockerfile](1.11/main/Dockerfile))
-- `arm`, `1.11-arm`, `1.11.7-arm` ([1.11/arm/Dockerfile](1.11/arm/Dockerfile))
-- `powerpc`, `1.11-powerpc`, `1.11.7-powerpc` ([1.11/powerpc/Dockerfile](1.11/powerpc/Dockerfile))
-- `mips`, `1.11-mips`, `1.11.7-mips` ([1.11/mips/Dockerfile](1.11/mips/Dockerfile))
-- `s390x`, `1.11-s390x`, `1.11.7-s390x` ([1.11/s390x/Dockerfile](1.11/s390x/Dockerfile))
+- `latest`, `main`, `1.12-main`, `1.12.3-main` ([1.12/main/Dockerfile](1.12/main/Dockerfile))
+- `arm`, `1.12-arm`, `1.12.3-arm` ([1.12/arm/Dockerfile](1.12/arm/Dockerfile))
+- `powerpc`, `1.12-powerpc`, `1.12.3-powerpc` ([1.12/powerpc/Dockerfile](1.12/powerpc/Dockerfile))
+- `mips`, `1.12-mips`, `1.12.3-mips` ([1.12/mips/Dockerfile](1.12/mips/Dockerfile))
+- `s390x`, `1.12-s390x`, `1.12.3-s390x` ([1.12/s390x/Dockerfile](1.12/s390x/Dockerfile))
+- `1.11-main`, `1.11.8-main` ([1.11/main/Dockerfile](1.11/main/Dockerfile))
+- `arm`, `1.11-arm`, `1.11.8-arm` ([1.11/arm/Dockerfile](1.11/arm/Dockerfile))
+- `powerpc`, `1.11-powerpc`, `1.11.8-powerpc` ([1.11/powerpc/Dockerfile](1.11/powerpc/Dockerfile))
+- `mips`, `1.11-mips`, `1.11.8-mips` ([1.11/mips/Dockerfile](1.11/mips/Dockerfile))
+- `s390x`, `1.11-s390x`, `1.11.8-s390x` ([1.11/s390x/Dockerfile](1.11/s390x/Dockerfile))
 
 ## Usage
 


### PR DESCRIPTION
Sigh, there's a [bug](https://github.com/golang/go/issues/31293) in 1.12.2 and 1.11.7 hitting programs using cgo, I don't think that any Prometheus repository is using cgo anymore but in doubt, it is safer to keep up-to-date.
Hopefully after I submitted #63, I spent a couple of hours to write a quick & dirty [program](https://github.com/simonpasquier/sandbox/blob/master/cmd/builder-bumper/main.go) that updates the repository whenever patch versions of Go are released so this PR didn't took too long...