### PR TITLE
Use Circle CI's org context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ workflows:
           branches:
             ignore: master
     - build_master:
+        context: org-context
         filters:
           branches:
             only: master
@@ -51,4 +52,5 @@ workflows:
               only:
                 - master
     jobs:
-    - bump_version
+    - bump_version:
+        context: org-context


### PR DESCRIPTION
Circle CI's [contexts](https://circleci.com/docs/2.0/configuration-reference/#context) allow to declare environment level variables at the org level instead of per project.

