### PR TITLE
1.14: install nodejs and yarn in base image

### DIFF
--- a/1.14/base/Dockerfile
+++ b/1.14/base/Dockerfile
@@ -13,6 +13,10 @@ RUN \
             gnupg \
             libsnmp-dev \
             make \
+        && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+        && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
+        && apt-get update \
+        && apt-get install -y --no-install-recommends nodejs yarn \
         && rm -rf /var/lib/apt/lists/*
 
 ENV GOLANG_VERSION 1.14.2


### PR DESCRIPTION
Needed for https://github.com/prometheus/prometheus/pull/7100.