### PR TITLE
Fix bumper version string handling

### DIFF
--- a/cmd/builder-bumper/main.go
+++ b/cmd/builder-bumper/main.go
@@ -76,12 +76,12 @@ func (g *goVersion) golangVersion() string {
 	if g.minor == 0 {
 		return g.Major()
 	}
-	return g.String()
+	return fmt.Sprintf("1.%d.%d", g.major, g.minor)
 }
 
 // String returns the full version string.
 func (g *goVersion) String() string {
-	return fmt.Sprintf("1.%d.%d", g.major, g.minor)
+	return g.golangVersion()
 }
 
 func (g *goVersion) less(o *goVersion) bool {


### PR DESCRIPTION
Return new major version strings correctly when calling
`goVersion.String()`.

Signed-off-by: SuperQ <superq@gmail.com>