### PR TITLE
Adjust version bump cron time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 6 * * *"
+          cron: "11 12 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
Run in the middle of the day (UTC).
* `echo $((RANDOM % 60))` for the minute.

Signed-off-by: SuperQ <superq@gmail.com>