### PR TITLE
Install openssh-client

### DIFF
--- a/1.16/base/Dockerfile
+++ b/1.16/base/Dockerfile
@@ -18,6 +18,7 @@ RUN \
             make \
             unzip \
             yamllint \
+            openssh-client \
         && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
         && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
         && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \

--- a/1.17/base/Dockerfile
+++ b/1.17/base/Dockerfile
@@ -18,6 +18,7 @@ RUN \
             make \
             unzip \
             yamllint \
+            openssh-client \
         && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
         && echo "deb https://deb.nodesource.com/node_16.x/ buster main" > /etc/apt/sources.list.d/nodesource.list \
         && apt-get update \


### PR DESCRIPTION
"Either git or ssh (required by git to clone through SSH) is not
installed in the image. Falling back to CircleCI's native git client but
the behavior may be different from official git. If this is an issue,
please use an image that has official git and ssh installed."

Signed-off-by: prombot <prometheus-team@googlegroups.com>