### PR TITLE
Call fullVersionReplacer before majorVersionReplacer

### DIFF
--- a/cmd/builder-bumper/main.go
+++ b/cmd/builder-bumper/main.go
@@ -280,8 +280,8 @@ func replaceMajor(old, current, next *goVersion) error {
 		[]func(string) (string, error){
 			fullVersionReplacer(current, next),
 			majorVersionReplacer(current, next),
-			majorVersionReplacer(old, current),
 			fullVersionReplacer(old, current),
+			majorVersionReplacer(old, current),
 		},
 	)
 }


### PR DESCRIPTION
Avoids changing 1.17.13 to 1.18.13.

Seen in #188.

Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>