### PR TITLE
Add support for RISC-V

### DIFF
--- a/1.18/main/Dockerfile
+++ b/1.18/main/Dockerfile
@@ -22,6 +22,8 @@ RUN \
         crossbuild-essential-powerpc linux-libc-dev-powerpc-cross \
         crossbuild-essential-ppc64el linux-libc-dev-ppc64el-cross \
         crossbuild-essential-s390x linux-libc-dev-s390x-cross \
+        gcc-riscv64-linux-gnu g++-riscv64-linux-gnu libc6-dev-riscv64-cross\
+        libc6-riscv64-cross linux-libc-dev-riscv64-cross\
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /tmp/osxcross
 

--- a/1.18/main/rootfs/builder.sh
+++ b/1.18/main/rootfs/builder.sh
@@ -55,6 +55,7 @@ do
         mips64le) cc='mips64el-linux-gnuabi64-gcc' cxx='mips64el-linux-gnuabi64-g++' ;;
         ppc64) cc='powerpc-linux-gnu-gcc' cxx='powerpc-linux-gnu-g++' ;;
         ppc64le) cc='powerpc64le-linux-gnu-gcc' cxx='powerpc64le-linux-gnu-g++' ;;
+        riscv64) cc='riscv64-linux-gnu-gcc' cxx='riscv64-linux-gnu-g++' ;;
         s390x) cc='gcc-s390x-linux-gnu' cxx='g++-s390x-linux-gnu' ;;
       esac
       ;;

--- a/1.19/main/Dockerfile
+++ b/1.19/main/Dockerfile
@@ -22,6 +22,8 @@ RUN \
         crossbuild-essential-powerpc linux-libc-dev-powerpc-cross \
         crossbuild-essential-ppc64el linux-libc-dev-ppc64el-cross \
         crossbuild-essential-s390x linux-libc-dev-s390x-cross \
+        gcc-riscv64-linux-gnu g++-riscv64-linux-gnu libc6-dev-riscv64-cross\
+        libc6-riscv64-cross linux-libc-dev-riscv64-cross\
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /tmp/osxcross
 

--- a/1.19/main/rootfs/builder.sh
+++ b/1.19/main/rootfs/builder.sh
@@ -55,6 +55,7 @@ do
         mips64le) cc='mips64el-linux-gnuabi64-gcc' cxx='mips64el-linux-gnuabi64-g++' ;;
         ppc64) cc='powerpc-linux-gnu-gcc' cxx='powerpc-linux-gnu-g++' ;;
         ppc64le) cc='powerpc64le-linux-gnu-gcc' cxx='powerpc64le-linux-gnu-g++' ;;
+        riscv64) cc='riscv64-linux-gnu-gcc' cxx='riscv64-linux-gnu-g++' ;;
         s390x) cc='gcc-s390x-linux-gnu' cxx='g++-s390x-linux-gnu' ;;
       esac
       ;;


### PR DESCRIPTION
The `crossbuild-essential-riscv64` is still missing from the Debian Bullseye repositories, see [here](https://wiki.debian.org/RISC-V#Using_pre-built_toolchains_with_sbuild). However, in the meantime, most cross build packages can be installed manually, except `libasan6-riscv64-cross`, `libitm1-riscv64-cross` and `libubsan1-riscv64-cross`. But I did manage to compile [Prometheus](https://github.com/prometheus/prometheus/):
```
$ docker run --rm -ti -v $(pwd):/app quay.io/prometheus/golang-builder:1.19.4-main-master -i "github.com/prometheus/prometheus" -p "linux/riscv64"
$ file .build/linux-riscv64/*
.build/linux-riscv64/prometheus: ELF 64-bit LSB executable, UCB RISC-V, double-float ABI, version 1 (SYSV), statically linked, Go BuildID=I6ddeoI6CtcOMXiufYwO/J5ZrZY7GbnRQExEVuz5e/VbwXUqeb2-nXdvPi3sga/LqmeSIFmkdL4orGazs0U, with debug_info, not stripped
.build/linux-riscv64/promtool:   ELF 64-bit LSB executable, UCB RISC-V, double-float ABI, version 1 (SYSV), statically linked, Go BuildID=HIsYqpLzHYIo9Vzbo8eO/TK3L82CoUyLYrBrKnL1S/G9QkQdhK4yOKK1EWUMNT/Z4TxPrJ9cIA1s3wcylXJ, with debug_info
```
These binaries also ran successfully on my RISC-V SBC with an Allwinner D1 CPU.

If these patches are merged, I should also update the [crossbuild](https://github.com/prometheus/promu/blob/master/cmd/crossbuild.go) system of [promu](https://github.com/prometheus/promu).

Signed-off-by: boosterl [bram.oosterlynck@gmail.com](mailto:bram.oosterlynck@gmail.com)