### PR TITLE
Update build dependencies

### DIFF
--- a/1.19/base/Dockerfile
+++ b/1.19/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM goreleaser/goreleaser:v1.16.0 as goreleaser
+FROM goreleaser/goreleaser:v1.19.2 as goreleaser
 
 FROM        debian:bullseye
 MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
@@ -24,8 +24,8 @@ RUN \
         && echo "deb https://deb.nodesource.com/node_16.x/ bullseye main" > /etc/apt/sources.list.d/nodesource.list \
         && apt-get update \
         && apt-get install -y --no-install-recommends nodejs \
-        && curl -s -f -L https://github.com/mikefarah/yq/releases/download/v4.31.2/yq_linux_amd64 -o "/bin/yq" \
-        && echo "71ef4141dbd9aec3f7fb45963b92460568d044245c945a7390831a5a470623f7 /bin/yq" > /tmp/yq.sum \
+        && curl -s -f -L https://github.com/mikefarah/yq/releases/download/v4.34.2/yq_linux_amd64 -o "/bin/yq" \
+        && echo "1952f93323e871700325a70610d2b33bafae5fe68e6eb4aec0621214f39a4c1e /bin/yq" > /tmp/yq.sum \
         && sha256sum -c /tmp/yq.sum \
         && chmod  0755 /bin/yq \
         && rm -rf /tmp/yq.sum /var/lib/apt/lists/*
@@ -49,8 +49,8 @@ COPY rootfs /
 
 COPY --from=goreleaser /usr/bin/goreleaser /usr/bin/goreleaser
 
-RUN curl -s -f -L https://github.com/gotestyourself/gotestsum/releases/download/v1.9.0/gotestsum_1.9.0_linux_amd64.tar.gz -o gotestsum.tar.gz \
-    && echo "0a0a310d6331447559b836407bcb4b98e758b9d4d3d829f3505f55ec74b26cae gotestsum.tar.gz" | sha256sum -c - \
+RUN curl -s -f -L https://github.com/gotestyourself/gotestsum/releases/download/v1.10.1/gotestsum_1.10.1_linux_amd64.tar.gz -o gotestsum.tar.gz \
+    && echo "44be2c02d4cf99cdd61edcb27851ef98ef8724a2ae3355b438bd108e9abb9056 gotestsum.tar.gz" | sha256sum -c - \
     && tar -C /usr/local -xzf gotestsum.tar.gz gotestsum \
     && rm gotestsum.tar.gz
 

--- a/1.20/base/Dockerfile
+++ b/1.20/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM goreleaser/goreleaser:v1.16.0 as goreleaser
+FROM goreleaser/goreleaser:v1.19.2 as goreleaser
 
 FROM        debian:bullseye
 MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
@@ -24,8 +24,8 @@ RUN \
         && echo "deb https://deb.nodesource.com/node_16.x/ bullseye main" > /etc/apt/sources.list.d/nodesource.list \
         && apt-get update \
         && apt-get install -y --no-install-recommends nodejs \
-        && curl -s -f -L https://github.com/mikefarah/yq/releases/download/v4.31.2/yq_linux_amd64 -o "/bin/yq" \
-        && echo "71ef4141dbd9aec3f7fb45963b92460568d044245c945a7390831a5a470623f7 /bin/yq" > /tmp/yq.sum \
+        && curl -s -f -L https://github.com/mikefarah/yq/releases/download/v4.34.2/yq_linux_amd64 -o "/bin/yq" \
+        && echo "1952f93323e871700325a70610d2b33bafae5fe68e6eb4aec0621214f39a4c1e /bin/yq" > /tmp/yq.sum \
         && sha256sum -c /tmp/yq.sum \
         && chmod  0755 /bin/yq \
         && rm -rf /tmp/yq.sum /var/lib/apt/lists/*
@@ -49,8 +49,8 @@ COPY rootfs /
 
 COPY --from=goreleaser /usr/bin/goreleaser /usr/bin/goreleaser
 
-RUN curl -s -f -L https://github.com/gotestyourself/gotestsum/releases/download/v1.9.0/gotestsum_1.9.0_linux_amd64.tar.gz -o gotestsum.tar.gz \
-    && echo "0a0a310d6331447559b836407bcb4b98e758b9d4d3d829f3505f55ec74b26cae gotestsum.tar.gz" | sha256sum -c - \
+RUN curl -s -f -L https://github.com/gotestyourself/gotestsum/releases/download/v1.10.1/gotestsum_1.10.1_linux_amd64.tar.gz -o gotestsum.tar.gz \
+    && echo "44be2c02d4cf99cdd61edcb27851ef98ef8724a2ae3355b438bd108e9abb9056 gotestsum.tar.gz" | sha256sum -c - \
     && tar -C /usr/local -xzf gotestsum.tar.gz gotestsum \
     && rm gotestsum.tar.gz
 

--- a/cmd/builder-bumper/main.go
+++ b/cmd/builder-bumper/main.go
@@ -28,7 +28,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
 )
 
@@ -170,7 +169,7 @@ func getExactVersionFromDir(d string) (*goVersion, error) {
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-	return nil, errors.Errorf("couldn't get exact version for %s", d)
+	return nil, fmt.Errorf("couldn't get exact version for %s", d)
 }
 
 func replace(filename string, replacers []func(string) (string, error)) error {
@@ -250,7 +249,7 @@ func replaceMajor(old, current, next *goVersion) error {
 		return err
 	}
 	if err := os.Rename(old.Major(), next.Major()); err != nil {
-		return errors.Wrap(err, "failed to create new version directory")
+		return fmt.Errorf("failed to create new version directory: %w", err)
 	}
 
 	// Update CircleCI.
@@ -291,7 +290,7 @@ func replaceMajor(old, current, next *goVersion) error {
 func updateNextMinor(dir string) (*goVersion, error) {
 	current, err := getExactVersionFromDir(dir)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to detect current version of %s", dir)
+		return nil, fmt.Errorf("failed to detect current version of %s: %w", dir, err)
 	}
 
 	next, err := current.getLastMinorVersion()
@@ -364,7 +363,7 @@ func run() error {
 	}
 
 	if len(dirs) != 2 {
-		return errors.Errorf("Expected 2 versions of Go but got %d\n", len(dirs))
+		return fmt.Errorf("Expected 2 versions of Go but got %d\n", len(dirs))
 	}
 
 	// Check if a new major Go version exists.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
 module github.com/prometheus/golang-builder
 
-go 1.18
+go 1.19
 
-require (
-	github.com/pkg/errors v0.9.1
-	golang.org/x/mod v0.11.0
-)
+require golang.org/x/mod v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-golang.org/x/mod v0.11.0 h1:bUO06HqtnRcc/7l71XBe4WcqTZ+3AH1J59zWDDwLKgU=
-golang.org/x/mod v0.11.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
+golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=


### PR DESCRIPTION
Update various build dependencies.
* Replace deprecated `github.com/pkg/errors` package.
* Update `golang.org/x/mod`.
* Update goreleaser to v1.19.2.
* Update yq to v4.34.2.
* Update gotestsum to v1.10.1.