### PR TITLE
fix: Correct base image in 1.21/main

### DIFF
--- a/1.21/main/Dockerfile
+++ b/1.21/main/Dockerfile
@@ -1,4 +1,4 @@
-FROM        quay.io/prometheus/golang-builder:1.19-base
+FROM        quay.io/prometheus/golang-builder:1.21-base
 MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 
 RUN \


### PR DESCRIPTION
Hello,

Looking into tag `1.21-main`, I found that the base image is incorrect. Tag `1.21-main` is using [`1.19-base`](https://github.com/prometheus/golang-builder/blob/245cf295cd7537c60f2b681a7151e770a85eec0d/1.21/main/Dockerfile#L1) as base image and hence, `go` version inside the container is still `1.19`.

This can be verified as follows:

```
docker run -v $PWD:/app -it --rm --entrypoint /bin/bash quay.io/prometheus/golang-builder:1.21-main
root@bb3024ca8c3f:/app# go version
go version go1.19.12 linux/amd64
root@bb3024ca8c3f:/app# which go
/usr/local/go/bin/go
```

This PR corrects the base image tag to use `1.21-base`.