### PR TITLE
Find new versions by parsing json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-builder-bumper
+builder-bumper/builder-bumper
 /docker-images

--- a/cmd/builder-bumper/main.go
+++ b/cmd/builder-bumper/main.go
@@ -127,7 +127,7 @@ func fetchJSON(url string) ([]byte, error) {
 
 func availableVersions() []goVersion {
 
-	url := "https://go.dev/dl/?mode=json"
+	const url = "https://go.dev/dl/?mode=json"
 
 	jsonData, err := fetchJSON(url)
 	if err != nil {
@@ -140,9 +140,8 @@ func availableVersions() []goVersion {
 		fmt.Println("Error parsing JSON:", err)
 	}
 	for i := range availableVersionsJSON {
-		// replace "go" from a string like "go1.22.0"
-		availableVersionsJSON[i].Version = strings.Replace(availableVersionsJSON[i].Version, "go", "", 1)
-		newGoVersion := newGoVersion(availableVersionsJSON[i].Version)
+		// remove "go" from a string like "go1.22.0"
+		newGoVersion := newGoVersion(strings.TrimLeft("go", availableVersionsJSON[i].Version))
 		availableVersions = append(availableVersions, *newGoVersion)
 	}
 	return availableVersions

--- a/cmd/builder-bumper/main.go
+++ b/cmd/builder-bumper/main.go
@@ -126,7 +126,6 @@ func fetchJSON(url string) ([]byte, error) {
 }
 
 func availableVersions() []goVersion {
-
 	const url = "https://go.dev/dl/?mode=json"
 
 	jsonData, err := fetchJSON(url)
@@ -139,9 +138,10 @@ func availableVersions() []goVersion {
 	if err := json.Unmarshal(jsonData, &availableVersionsJSON); err != nil {
 		fmt.Println("Error parsing JSON:", err)
 	}
+
 	for i := range availableVersionsJSON {
 		// remove "go" from a string like "go1.22.0"
-		newGoVersion := newGoVersion(strings.TrimLeft("go", availableVersionsJSON[i].Version))
+		newGoVersion := newGoVersion(strings.TrimLeft(availableVersionsJSON[i].Version, "go"))
 		availableVersions = append(availableVersions, *newGoVersion)
 	}
 	return availableVersions

--- a/cmd/builder-bumper/main.go
+++ b/cmd/builder-bumper/main.go
@@ -164,18 +164,20 @@ func (g *goVersion) getSHA256() (string, error) {
 // getLastMinorVersion returns the last minor version for a given Go version.
 // if no new minor version available, it will return the given Go version back.
 func (g *goVersion) getLastMinorVersion(availableVersions []goVersion) *goVersion {
-	last := *g
-	next := last
-	// let's check max 40 minor revisions for now before giving up
-	for next.minor < 40 {
-		next.minor++
-		for _, availableVersion := range availableVersions {
-			if next == availableVersion {
-				return &next
-			}
+	sort.Slice(availableVersions, func(i, j int) bool {
+		if availableVersions[i].major == availableVersions[j].major {
+			return availableVersions[i].minor < availableVersions[j].minor
+		}
+		return availableVersions[i].major < availableVersions[j].major
+	})
+
+	for _, availableVersion := range availableVersions {
+		if availableVersion.major == g.major && availableVersion.minor > g.minor {
+			return &availableVersion
 		}
 	}
-	return &last
+
+	return g
 }
 
 // getNextMajor returns the next Go major version for a given Go version.

--- a/cmd/builder-bumper/main.go
+++ b/cmd/builder-bumper/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -44,6 +45,10 @@ func init() {
 type goVersion struct {
 	major int
 	minor int
+}
+
+type VersionInfo struct {
+	Version string `json:"version"`
 }
 
 func newGoVersion(v string) *goVersion {
@@ -101,6 +106,48 @@ func (g *goVersion) url() string {
 	return fmt.Sprintf("https://dl.google.com/go/go%s.linux-amd64.tar.gz", g.golangVersion())
 }
 
+func fetchJSON(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func availableVersions() []goVersion {
+
+	url := "https://go.dev/dl/?mode=json"
+
+	jsonData, err := fetchJSON(url)
+	if err != nil {
+		fmt.Println("Error fetching JSON:", err)
+	}
+
+	var availableVersionsJSON []VersionInfo
+	var availableVersions []goVersion
+	if err := json.Unmarshal(jsonData, &availableVersionsJSON); err != nil {
+		fmt.Println("Error parsing JSON:", err)
+	}
+	for i := range availableVersionsJSON {
+		// replace "go" from a string like "go1.22.0"
+		availableVersionsJSON[i].Version = strings.Replace(availableVersionsJSON[i].Version, "go", "", 1)
+		newGoVersion := newGoVersion(availableVersionsJSON[i].Version)
+		availableVersions = append(availableVersions, *newGoVersion)
+	}
+	return availableVersions
+}
+
 // getSHA256 returns the SHA256 of the Go archive.
 func (g *goVersion) getSHA256() (string, error) {
 	resp, err := http.Get(g.url() + ".sha256")
@@ -116,40 +163,34 @@ func (g *goVersion) getSHA256() (string, error) {
 }
 
 // getLastMinorVersion returns the last minor version for a given Go version.
-func (g *goVersion) getLastMinorVersion() (*goVersion, error) {
+// if no new minor version available, it will return the given Go version back.
+func (g *goVersion) getLastMinorVersion(availableVersions []goVersion) *goVersion {
 	last := *g
-	for {
-		next := last
+	next := last
+	// let's check max 40 minor revisions for now before giving up
+	for next.minor < 40 {
 		next.minor++
-		resp, err := http.Head(next.url())
-		if err != nil {
-			return nil, err
+		for _, availableVersion := range availableVersions {
+			if next == availableVersion {
+				return &next
+			}
 		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode/100 != 2 {
-			return &last, nil
-		}
-		last = next
 	}
+	return &last
 }
 
 // getNextMajor returns the next Go major version for a given Go version.
 // It returns nil if the current version is already the latest.
-func (g *goVersion) getNextMajor() *goVersion {
+func (g *goVersion) getNextMajor(availableVersions []goVersion) *goVersion {
 	version := newGoVersion(g.Major() + ".0")
 	version.major++
 
-	resp, err := http.Head(version.url())
-	if err != nil {
-		return nil
+	for _, availableVersion := range availableVersions {
+		if version.major == availableVersion.major {
+			return version
+		}
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode/100 != 2 {
-		return nil
-	}
-
-	return version
+	return nil
 }
 
 // getExactVersionFromDir reads the current Go version from a directory.
@@ -301,10 +342,8 @@ func updateNextMinor(dir string) (*goVersion, error) {
 		return nil, fmt.Errorf("failed to detect current version of %s: %w", dir, err)
 	}
 
-	next, err := current.getLastMinorVersion()
-	if err != nil {
-		return nil, err
-	}
+	next := current.getLastMinorVersion(availableVersions())
+
 	if next.equal(current) {
 		log.Printf("no version change for Go %s", next.golangVersion())
 		return nil, nil
@@ -374,9 +413,12 @@ func run() error {
 		return fmt.Errorf("Expected 2 versions of Go but got %d\n", len(dirs))
 	}
 
+	// Get list of available versions
+	availableVersions := availableVersions()
+
 	// Check if a new major Go version exists.
 	nexts := make([]*goVersion, 0)
-	if next := newGoVersion(dirs[1] + ".0").getNextMajor(); next != nil {
+	if next := newGoVersion(dirs[1] + ".0").getNextMajor(availableVersions); next != nil {
 		log.Printf("found a new major version of Go: %s", next)
 		old, err := getExactVersionFromDir(dirs[0])
 		if err != nil {

--- a/cmd/builder-bumper/main_test.go
+++ b/cmd/builder-bumper/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNewGoVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  *goVersion
+	}{
+		{"1.22.1", &goVersion{22, 1}},
+		{"1.20.5", &goVersion{20, 5}},
+		{"1.19.0", &goVersion{19, 0}},
+		{"1.25.3", &goVersion{25, 3}},
+		{"1.18.10", &goVersion{18, 10}},
+	}
+
+	for _, tt := range tests {
+		t.Run("Parsing "+tt.input, func(t *testing.T) {
+			got := newGoVersion(tt.input)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newGoVersion(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAvailableVersions(t *testing.T) {
+	t.Run("Test that available versions scan correctly removes 'go' prefix", func(t *testing.T) {
+		got := availableVersions()
+
+		if len(got) == 0 {
+			t.Fatalf("Expected some versions, got none")
+		}
+
+		for _, v := range got {
+			if strings.Contains(v.String(), "go") {
+				t.Errorf("Version still contains 'go' prefix: %v", v)
+			}
+		}
+	})
+}


### PR DESCRIPTION
@SuperQ one attempt at fixing: https://github.com/prometheus/golang-builder/issues/216

This should keep the current functionality as far as my testing goes. Now just getting the versions from the said json file.

What do you think?