### PR TITLE
Temporary fix for no go2.23 at circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   golang:
     docker:
-    - image: cimg/go:1.23
+    - image: cimg/go:1.22
   vm:
     machine:
       image: ubuntu-2204:current


### PR DESCRIPTION
cimg/go:1.23 is not available yet