### PR TITLE
Update Go

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,14 +26,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: 1.24.x
       - name: Install snmp_exporter/generator dependencies
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
         if: github.repository == 'prometheus/snmp_exporter'
       - name: Lint
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           args: --verbose
-          version: v1.64.6
+          version: v2.0.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+linters:
+  exclusions:
+    rules:
+      - linters:
+          - errcheck
+        # Taken from the default exclusions in v1.
+        text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+
+version: "2"

--- a/cmd/builder-bumper/main.go
+++ b/cmd/builder-bumper/main.go
@@ -422,7 +422,7 @@ func run() error {
 	}
 
 	if len(dirs) != 2 {
-		return fmt.Errorf("Expected 2 versions of Go but got %d\n", len(dirs))
+		return fmt.Errorf("expected 2 versions of Go but got %d", len(dirs))
 	}
 
 	// Get list of available versions

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/prometheus/golang-builder
 
-go 1.22.0
+go 1.23.0
 
-require golang.org/x/mod v0.23.0
+require golang.org/x/mod v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
-golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=


### PR DESCRIPTION
* Update minimum Go version to 1.23.0
* Update Go modules.
* Update golangci-lint.
* Fixup linting issues.
