### PR TITLE
Fix fork builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PROM_OSX_SDK_URL: ${{ secrets.PROM_OSX_SDK_URL }}
+    if: github.repository_owner == 'prometheus'
     strategy:
       matrix:
         go:


### PR DESCRIPTION
Don't attempt to build from forks that are missing the OSX SDK secret.