### PR TITLE
Replace osxcross with zig for macOS cross-compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,40 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: make --always-make test-unit
 
+  extract-macos-sdk:
+    name: Extract macOS SDK
+    runs-on: macos-15
+    outputs:
+      sdk_version: ${{ steps.sdk.outputs.sdk_version }}
+    steps:
+      - name: Extract SDK files
+        id: sdk
+        run: |
+          SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+          SDK_VERSION="$(xcrun --sdk macosx --show-sdk-version)"
+          echo "sdk_version=${SDK_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Using SDK at ${SDKROOT} (version ${SDK_VERSION})"
+
+          mkdir -p sdk-files/Frameworks
+
+          cp -r "${SDKROOT}/usr/include" sdk-files/include
+          cp -r "${SDKROOT}/usr/lib" sdk-files/lib
+
+          for fw in CoreFoundation Foundation IOKit Security; do
+            cp -r "${SDKROOT}/System/Library/Frameworks/${fw}.framework" "sdk-files/Frameworks/${fw}.framework"
+          done
+
+      - name: Upload SDK artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: macos-sdk
+          path: sdk-files/
+          retention-days: 1
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    env:
-      PROM_OSX_SDK_URL: ${{ secrets.PROM_OSX_SDK_URL }}
+    needs: [extract-macos-sdk]
     strategy:
       matrix:
         go:
@@ -50,6 +79,11 @@ jobs:
         with:
           go-version: ${{ matrix.go }}.x
       - run: make VARIANTS=base VERSION=${{ matrix.go }}
+      - name: Download macOS SDK artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: macos-sdk
+          path: ${{ matrix.go }}/main/macos-sdk/
       - run: make VARIANTS=main VERSION=${{ matrix.go }}
       - run: docker images
       - run: ls -l docker-images

--- a/1.25/main/Dockerfile
+++ b/1.25/main/Dockerfile
@@ -1,9 +1,9 @@
 FROM        quay.io/prometheus/golang-builder:1.25-base
 LABEL       maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-ENV ZIG_VERSION=0.14.0 \
-    ZIG_SHA256=473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982 \
-    MACOS_SDK_PATH=/usr/local/lib/macos-sdk
+ENV ZIG_VERSION=0.14.0
+ENV ZIG_SHA256=473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982
+ENV MACOS_SDK_PATH=/usr/local/lib/macos-sdk
 
 RUN \
     apt-get update && apt-get install -y --no-install-recommends \

--- a/1.25/main/Dockerfile
+++ b/1.25/main/Dockerfile
@@ -1,19 +1,13 @@
-FROM rust:latest AS rustbuilder
-
-RUN cargo install --locked --git https://github.com/indygreg/apple-platform-rs --branch main --bin rcodesign apple-codesign
-
 FROM        quay.io/prometheus/golang-builder:1.25-base
 LABEL       maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
+ENV ZIG_VERSION=0.14.0 \
+    ZIG_SHA256=473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982 \
+    MACOS_SDK_PATH=/usr/local/lib/macos-sdk
+
 RUN \
     apt-get update && apt-get install -y --no-install-recommends \
-        clang \
-        cmake \
-        libc6-dev \
-        libxml2-dev \
-        lzma-dev \
         mingw-w64 \
-        patch \
         xz-utils \
         crossbuild-essential-arm64 linux-libc-dev-arm64-cross \
         crossbuild-essential-armel linux-libc-dev-armel-cross \
@@ -29,28 +23,16 @@ RUN \
         gcc-riscv64-linux-gnu g++-riscv64-linux-gnu libc6-dev-riscv64-cross \
         libc6-riscv64-cross linux-libc-dev-riscv64-cross \
     && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /tmp/osxcross
-    
-COPY --from=rustbuilder /usr/local/cargo/bin/rcodesign /usr/local/bin/rcodesign
+    && mkdir -p /usr/local/lib/zig \
+    && tar -C /usr/local/lib/zig --strip-components=1 -xJf \
+       "$(/bin/download.sh "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" \
+          "${ZIG_SHA256}")" \
+    && ln -s /usr/local/lib/zig/zig /usr/local/bin/zig
 
-ARG PROM_OSX_SDK_URL
-ENV OSXCROSS_PATH=/usr/osxcross \
-    OSXCROSS_REV=ff8d100f3f026b4ffbe4ce96d8aac4ce06f1278b \
-    SDK_VERSION=14 \
-    DARWIN_VERSION=23 \
-    OSX_VERSION_MIN=10.13
-
-WORKDIR /tmp/osxcross
-RUN \
-    curl -s -f -L "https://codeload.github.com/tpoechtrager/osxcross/tar.gz/${OSXCROSS_REV}" \
-      | tar -C /tmp/osxcross --strip=1 -xzf - \
-    && curl -s -f -L "${PROM_OSX_SDK_URL}/MacOSX${SDK_VERSION}.sdk.tar.xz" -o "tarballs/MacOSX${SDK_VERSION}.sdk.tar.xz" \
-    && UNATTENDED=yes JOBS=2 ./build.sh \
-    && mv target "${OSXCROSS_PATH}" \
-    && rm -rf /tmp/osxcross "/usr/osxcross/SDK/MacOSX${SDK_VERSION}.sdk/usr/share/man"
+COPY macos-sdk-bin/ /usr/local/lib/macos-sdk/bin/
+COPY macos-sdk/ /usr/local/lib/macos-sdk/
+RUN chmod +x /usr/local/lib/macos-sdk/bin/*
 
 WORKDIR /app
-
-ENV PATH=$OSXCROSS_PATH/bin:$PATH
 
 COPY rootfs /

--- a/1.25/main/Makefile
+++ b/1.25/main/Makefile
@@ -15,6 +15,6 @@ include ../Makefile.COMMON
 
 build:
 	@echo ">> building $(REPOSITORY)/$(NAME):$(VERSION)-$(DIRNAME)$(SUFFIX)"
-	@docker build -t "$(REPOSITORY)/$(NAME):$(VERSION)-$(DIRNAME)$(SUFFIX)" --build-arg PROM_OSX_SDK_URL=${PROM_OSX_SDK_URL} .
+	@docker build -t "$(REPOSITORY)/$(NAME):$(VERSION)-$(DIRNAME)$(SUFFIX)" .
 	@docker tag "$(REPOSITORY)/$(NAME):$(VERSION)-$(DIRNAME)$(SUFFIX)" "$(REPOSITORY)/$(NAME):$(VERSION)-$(DIRNAME)"
 	@docker save -o "$(IMAGE_DIR)/$(IMAGE_FILE)-$(VERSION)-$(DIRNAME)" "$(IMAGE):$(VERSION)-$(DIRNAME)"

--- a/1.25/main/macos-sdk-bin/dsymutil
+++ b/1.25/main/macos-sdk-bin/dsymutil
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 0

--- a/1.25/main/macos-sdk-bin/strip
+++ b/1.25/main/macos-sdk-bin/strip
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 0

--- a/1.25/main/macos-sdk-bin/zighelper
+++ b/1.25/main/macos-sdk-bin/zighelper
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+exec zig "$@" \
+    -target "${MACOS_TARGET}" \
+    -Wno-nullability-completeness \
+    -I "${MACOS_SDK_PATH}/include" \
+    -iframework "${MACOS_SDK_PATH}/Frameworks" \
+    -F "${MACOS_SDK_PATH}/Frameworks" \
+    -L "${MACOS_SDK_PATH}/lib"

--- a/1.25/main/rootfs/builder.sh
+++ b/1.25/main/rootfs/builder.sh
@@ -23,7 +23,7 @@ for goarch in "${goarchs[@]}"
 do
   goos=${goarch%%/*}
   arch=${goarch##*/}
-  goarm='' cc='gcc' cxx='g++' extra_args=''
+  goarm='' cc='gcc' cxx='g++' extra_args='' macos_path='' macos_target=''
 
   case "${goos}" in
     windows)
@@ -34,9 +34,11 @@ do
       ;;
     darwin)
       case "${arch}" in
-        amd64) cc='o64-clang' cxx='o64-clang++' extra_args='LD_LIBRARY_PATH=/usr/osxcross/lib' ;;
-        arm64) cc='oa64-clang' cxx='oa64-clang++' extra_args='LD_LIBRARY_PATH=/usr/osxcross/lib' ;;
+        amd64) macos_target='x86_64-macos.11.0' ;;
+        arm64) macos_target='aarch64-macos.11.0' ;;
       esac
+      cc='zighelper cc' cxx='zighelper c++'
+      macos_path="${MACOS_SDK_PATH}/bin:"
       ;;
     linux)
       case "${arch}" in
@@ -72,10 +74,10 @@ do
 
   echo "# Building with: CC='${cc}' CXX='${cxx}'"
   if [[ -n "${goarm}" ]]; then
-    CC="${cc}" CXX="${cxx}" GOOS="${goos}" GOARCH="${arch}" GOARM="${goarm}" \
+    PATH="${macos_path}${PATH}" MACOS_TARGET="${macos_target}" CC="${cc}" CXX="${cxx}" GOOS="${goos}" GOARCH="${arch}" GOARM="${goarm}" \
       make PREFIX="${prefix}" build ${extra_args}
   else
-    CC="${cc}" CXX="${cxx}" GOOS="${goos}" GOARCH="${arch}" \
+    PATH="${macos_path}${PATH}" MACOS_TARGET="${macos_target}" CC="${cc}" CXX="${cxx}" GOOS="${goos}" GOARCH="${arch}" \
       make PREFIX="${prefix}" build ${extra_args}
   fi
 done

--- a/1.26/main/Dockerfile
+++ b/1.26/main/Dockerfile
@@ -1,19 +1,13 @@
-FROM rust:latest AS rustbuilder
-
-RUN cargo install --locked --git https://github.com/indygreg/apple-platform-rs --branch main --bin rcodesign apple-codesign
-
 FROM        quay.io/prometheus/golang-builder:1.26-base
 LABEL       maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
+ENV ZIG_VERSION=0.14.0 \
+    ZIG_SHA256=473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982 \
+    MACOS_SDK_PATH=/usr/local/lib/macos-sdk
+
 RUN \
     apt-get update && apt-get install -y --no-install-recommends \
-        clang \
-        cmake \
-        libc6-dev \
-        libxml2-dev \
-        lzma-dev \
         mingw-w64 \
-        patch \
         xz-utils \
         crossbuild-essential-arm64 linux-libc-dev-arm64-cross \
         crossbuild-essential-armel linux-libc-dev-armel-cross \
@@ -29,28 +23,16 @@ RUN \
         gcc-riscv64-linux-gnu g++-riscv64-linux-gnu libc6-dev-riscv64-cross \
         libc6-riscv64-cross linux-libc-dev-riscv64-cross \
     && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /tmp/osxcross
-    
-COPY --from=rustbuilder /usr/local/cargo/bin/rcodesign /usr/local/bin/rcodesign
+    && mkdir -p /usr/local/lib/zig \
+    && tar -C /usr/local/lib/zig --strip-components=1 -xJf \
+       "$(/bin/download.sh "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" \
+          "${ZIG_SHA256}")" \
+    && ln -s /usr/local/lib/zig/zig /usr/local/bin/zig
 
-ARG PROM_OSX_SDK_URL
-ENV OSXCROSS_PATH=/usr/osxcross \
-    OSXCROSS_REV=ff8d100f3f026b4ffbe4ce96d8aac4ce06f1278b \
-    SDK_VERSION=14 \
-    DARWIN_VERSION=23 \
-    OSX_VERSION_MIN=10.13
-
-WORKDIR /tmp/osxcross
-RUN \
-    curl -s -f -L "https://codeload.github.com/tpoechtrager/osxcross/tar.gz/${OSXCROSS_REV}" \
-      | tar -C /tmp/osxcross --strip=1 -xzf - \
-    && curl -s -f -L "${PROM_OSX_SDK_URL}/MacOSX${SDK_VERSION}.sdk.tar.xz" -o "tarballs/MacOSX${SDK_VERSION}.sdk.tar.xz" \
-    && UNATTENDED=yes JOBS=2 ./build.sh \
-    && mv target "${OSXCROSS_PATH}" \
-    && rm -rf /tmp/osxcross "/usr/osxcross/SDK/MacOSX${SDK_VERSION}.sdk/usr/share/man"
+COPY macos-sdk-bin/ /usr/local/lib/macos-sdk/bin/
+COPY macos-sdk/ /usr/local/lib/macos-sdk/
+RUN chmod +x /usr/local/lib/macos-sdk/bin/*
 
 WORKDIR /app
-
-ENV PATH=$OSXCROSS_PATH/bin:$PATH
 
 COPY rootfs /

--- a/1.26/main/Dockerfile
+++ b/1.26/main/Dockerfile
@@ -1,9 +1,9 @@
 FROM        quay.io/prometheus/golang-builder:1.26-base
 LABEL       maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-ENV ZIG_VERSION=0.14.0 \
-    ZIG_SHA256=473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982 \
-    MACOS_SDK_PATH=/usr/local/lib/macos-sdk
+ENV ZIG_VERSION=0.14.0
+ENV ZIG_SHA256=473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982
+ENV MACOS_SDK_PATH=/usr/local/lib/macos-sdk
 
 RUN \
     apt-get update && apt-get install -y --no-install-recommends \

--- a/1.26/main/Makefile
+++ b/1.26/main/Makefile
@@ -15,6 +15,6 @@ include ../Makefile.COMMON
 
 build:
 	@echo ">> building $(REPOSITORY)/$(NAME):$(VERSION)-$(DIRNAME)$(SUFFIX)"
-	@docker build -t "$(REPOSITORY)/$(NAME):$(VERSION)-$(DIRNAME)$(SUFFIX)" --build-arg PROM_OSX_SDK_URL=${PROM_OSX_SDK_URL} .
+	@docker build -t "$(REPOSITORY)/$(NAME):$(VERSION)-$(DIRNAME)$(SUFFIX)" .
 	@docker tag "$(REPOSITORY)/$(NAME):$(VERSION)-$(DIRNAME)$(SUFFIX)" "$(REPOSITORY)/$(NAME):$(VERSION)-$(DIRNAME)"
 	@docker save -o "$(IMAGE_DIR)/$(IMAGE_FILE)-$(VERSION)-$(DIRNAME)" "$(IMAGE):$(VERSION)-$(DIRNAME)"

--- a/1.26/main/macos-sdk-bin/dsymutil
+++ b/1.26/main/macos-sdk-bin/dsymutil
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 0

--- a/1.26/main/macos-sdk-bin/strip
+++ b/1.26/main/macos-sdk-bin/strip
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 0

--- a/1.26/main/macos-sdk-bin/zighelper
+++ b/1.26/main/macos-sdk-bin/zighelper
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+exec zig "$@" \
+    -target "${MACOS_TARGET}" \
+    -Wno-nullability-completeness \
+    -I "${MACOS_SDK_PATH}/include" \
+    -iframework "${MACOS_SDK_PATH}/Frameworks" \
+    -F "${MACOS_SDK_PATH}/Frameworks" \
+    -L "${MACOS_SDK_PATH}/lib"

--- a/1.26/main/rootfs/builder.sh
+++ b/1.26/main/rootfs/builder.sh
@@ -23,7 +23,7 @@ for goarch in "${goarchs[@]}"
 do
   goos=${goarch%%/*}
   arch=${goarch##*/}
-  goarm='' cc='gcc' cxx='g++' extra_args=''
+  goarm='' cc='gcc' cxx='g++' extra_args='' macos_path='' macos_target=''
 
   case "${goos}" in
     windows)
@@ -34,9 +34,11 @@ do
       ;;
     darwin)
       case "${arch}" in
-        amd64) cc='o64-clang' cxx='o64-clang++' extra_args='LD_LIBRARY_PATH=/usr/osxcross/lib' ;;
-        arm64) cc='oa64-clang' cxx='oa64-clang++' extra_args='LD_LIBRARY_PATH=/usr/osxcross/lib' ;;
+        amd64) macos_target='x86_64-macos.11.0' ;;
+        arm64) macos_target='aarch64-macos.11.0' ;;
       esac
+      cc='zighelper cc' cxx='zighelper c++'
+      macos_path="${MACOS_SDK_PATH}/bin:"
       ;;
     linux)
       case "${arch}" in
@@ -72,10 +74,10 @@ do
 
   echo "# Building with: CC='${cc}' CXX='${cxx}'"
   if [[ -n "${goarm}" ]]; then
-    CC="${cc}" CXX="${cxx}" GOOS="${goos}" GOARCH="${arch}" GOARM="${goarm}" \
+    PATH="${macos_path}${PATH}" MACOS_TARGET="${macos_target}" CC="${cc}" CXX="${cxx}" GOOS="${goos}" GOARCH="${arch}" GOARM="${goarm}" \
       make PREFIX="${prefix}" build ${extra_args}
   else
-    CC="${cc}" CXX="${cxx}" GOOS="${goos}" GOARCH="${arch}" \
+    PATH="${macos_path}${PATH}" MACOS_TARGET="${macos_target}" CC="${cc}" CXX="${cxx}" GOOS="${goos}" GOARCH="${arch}" \
       make PREFIX="${prefix}" build ${extra_args}
   fi
 done

--- a/build.sh
+++ b/build.sh
@@ -17,11 +17,6 @@ set -e
 
 [ "$#" -lt 2 ] && echo "Missing args: $0 {VERSIONS} {VARIANTS}";
 
-if [[ -z "${PROM_OSX_SDK_URL}" ]]; then
-  echo "Missing PROM_OSX_SDK_URL env var"
-  exit 1
-fi
-
 versions=( $1 )
 variants=( $2 )
 

--- a/macos-sdk-bin/dsymutil
+++ b/macos-sdk-bin/dsymutil
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 0

--- a/macos-sdk-bin/strip
+++ b/macos-sdk-bin/strip
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 0

--- a/macos-sdk-bin/zighelper
+++ b/macos-sdk-bin/zighelper
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+exec zig "$@" \
+    -target "${MACOS_TARGET}" \
+    -Wno-nullability-completeness \
+    -I "${MACOS_SDK_PATH}/include" \
+    -iframework "${MACOS_SDK_PATH}/Frameworks" \
+    -F "${MACOS_SDK_PATH}/Frameworks" \
+    -L "${MACOS_SDK_PATH}/lib"


### PR DESCRIPTION
Switch from osxcross (which required a private SDK URL and a Rust build stage) to zig cc/c++ wrappers, removing the PROM_OSX_SDK_URL secret dependency entirely.