### PR TITLE
Bump macOS target to 12.0 and update CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
   extract-macos-sdk:
     name: Extract macOS SDK
-    runs-on: macos-15
+    runs-on: macos-26
     outputs:
       sdk_version: ${{ steps.sdk.outputs.sdk_version }}
     steps:

--- a/1.25/main/rootfs/builder.sh
+++ b/1.25/main/rootfs/builder.sh
@@ -34,8 +34,8 @@ do
       ;;
     darwin)
       case "${arch}" in
-        amd64) macos_target='x86_64-macos.11.0' ;;
-        arm64) macos_target='aarch64-macos.11.0' ;;
+        amd64) macos_target='x86_64-macos.12.0' ;;
+        arm64) macos_target='aarch64-macos.12.0' ;;
       esac
       cc='zighelper cc' cxx='zighelper c++'
       macos_path="${MACOS_SDK_PATH}/bin:"

--- a/1.26/main/rootfs/builder.sh
+++ b/1.26/main/rootfs/builder.sh
@@ -34,8 +34,8 @@ do
       ;;
     darwin)
       case "${arch}" in
-        amd64) macos_target='x86_64-macos.11.0' ;;
-        arm64) macos_target='aarch64-macos.11.0' ;;
+        amd64) macos_target='x86_64-macos.12.0' ;;
+        arm64) macos_target='aarch64-macos.12.0' ;;
       esac
       cc='zighelper cc' cxx='zighelper c++'
       macos_path="${MACOS_SDK_PATH}/bin:"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ docker run --rm -ti -v $(pwd):/app quay.io/prometheus/golang-builder:mips \
     -p "linux/mips64 linux/mips64le"
 ```
 
+## Darwin/macOS CGO builds
+
+Darwin CGO cross-compilation uses [Zig](https://ziglang.org/) as the C compiler,
+combined with the macOS SDK provided by the GitHub-hosted macOS runner (the latest
+SDK available at image build time). Builds target macOS 12 (Monterey) and later,
+which is the [minimum version supported by Go](https://go.dev/wiki/Darwin).
+
+This is **not** a general-purpose macOS cross-compilation toolchain. It is scoped
+to the CGO surface needed by Prometheus ecosystem projects and may not support
+every CGO use case.
+
 ## Legal note
 
 OSX/Darwin/Apple builds:


### PR DESCRIPTION
macOS 12 is actually the minimum version supported by Go; update the zig cross-compilation targets and the SDK extraction runner accordingly. Add README section documenting the Darwin CGO build setup.