### PR TITLE
main: restore rcodesign from prebuilt binary

### DIFF
--- a/1.25/main/Dockerfile
+++ b/1.25/main/Dockerfile
@@ -4,6 +4,9 @@ LABEL       maintainer="The Prometheus Authors <prometheus-developers@googlegrou
 ENV ZIG_VERSION=0.14.0
 ENV ZIG_SHA256=473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982
 ENV MACOS_SDK_PATH=/usr/local/lib/macos-sdk
+ENV RCODESIGN_VERSION=0.29.0
+ENV RCODESIGN_URL=https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign/${RCODESIGN_VERSION}/apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl.tar.gz
+ENV RCODESIGN_SHA256=dbe85cedd8ee4217b64e9a0e4c2aef92ab8bcaaa41f20bde99781ff02e600002
 
 RUN \
     apt-get update && apt-get install -y --no-install-recommends \
@@ -27,7 +30,11 @@ RUN \
     && tar -C /usr/local/lib/zig --strip-components=1 -xJf \
        "$(/bin/download.sh "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" \
           "${ZIG_SHA256}")" \
-    && ln -s /usr/local/lib/zig/zig /usr/local/bin/zig
+    && ln -s /usr/local/lib/zig/zig /usr/local/bin/zig \
+    && rcodesign_file=$(/bin/download.sh "${RCODESIGN_URL}" "${RCODESIGN_SHA256}") \
+    && tar -C /usr/local/bin --strip-components=1 -xzf "${rcodesign_file}" \
+       "apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl/rcodesign" \
+    && rm "${rcodesign_file}"
 
 COPY macos-sdk-bin/ /usr/local/lib/macos-sdk/bin/
 COPY macos-sdk/ /usr/local/lib/macos-sdk/

--- a/1.26/main/Dockerfile
+++ b/1.26/main/Dockerfile
@@ -4,6 +4,9 @@ LABEL       maintainer="The Prometheus Authors <prometheus-developers@googlegrou
 ENV ZIG_VERSION=0.14.0
 ENV ZIG_SHA256=473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982
 ENV MACOS_SDK_PATH=/usr/local/lib/macos-sdk
+ENV RCODESIGN_VERSION=0.29.0
+ENV RCODESIGN_URL=https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign/${RCODESIGN_VERSION}/apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl.tar.gz
+ENV RCODESIGN_SHA256=dbe85cedd8ee4217b64e9a0e4c2aef92ab8bcaaa41f20bde99781ff02e600002
 
 RUN \
     apt-get update && apt-get install -y --no-install-recommends \
@@ -27,7 +30,11 @@ RUN \
     && tar -C /usr/local/lib/zig --strip-components=1 -xJf \
        "$(/bin/download.sh "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" \
           "${ZIG_SHA256}")" \
-    && ln -s /usr/local/lib/zig/zig /usr/local/bin/zig
+    && ln -s /usr/local/lib/zig/zig /usr/local/bin/zig \
+    && rcodesign_file=$(/bin/download.sh "${RCODESIGN_URL}" "${RCODESIGN_SHA256}") \
+    && tar -C /usr/local/bin --strip-components=1 -xzf "${rcodesign_file}" \
+       "apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl/rcodesign" \
+    && rm "${rcodesign_file}"
 
 COPY macos-sdk-bin/ /usr/local/lib/macos-sdk/bin/
 COPY macos-sdk/ /usr/local/lib/macos-sdk/


### PR DESCRIPTION
rcodesign was removed when switching from osxcross to zig. Re-add it by downloading the prebuilt musl binary from GitHub releases, avoiding the previous rust:latest build stage.