### PR TITLE
ci: use macos-15 runner for SDK extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
   extract-macos-sdk:
     name: Extract macOS SDK
-    runs-on: macos-26
+    runs-on: macos-15
     outputs:
       sdk_version: ${{ steps.sdk.outputs.sdk_version }}
     steps:


### PR DESCRIPTION
zig 0.14.0 uses LLVM 19/LLD which cannot parse the newer TBD format produced by the macOS 26 SDK, causing undefined symbol errors for CoreFoundation and other system framework symbols at link time. macOS 15 SDK uses TBD v4 which LLD supports.