### PR TITLE
Keep the CI build matrix in .ci-versions.yml

### DIFF
--- a/.ci-versions.yml
+++ b/.ci-versions.yml
@@ -1,0 +1,6 @@
+# Go major versions built by CI. Maintained by cmd/builder-bumper: it lives
+# outside .github/workflows/ because the workflow GITHUB_TOKEN can not push
+# changes to workflow files.
+go:
+  - "1.25"
+  - "1.26"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - "go.mod"
       - "**.go"
       - "*/Makefile.COMMON"
+      - ".ci-versions.yml"
       - "*/base/*"
       - "*/main/*"
       - ".github/workflows/ci.yml"
@@ -58,15 +59,27 @@ jobs:
           path: sdk-files/
           retention-days: 1
 
+  go-versions:
+    name: Determine Go versions
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.versions.outputs.versions }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Read .ci-versions.yml
+        id: versions
+        run: |
+          versions="$(yq -o=json -I=0 '.go' .ci-versions.yml)"
+          echo "Building Go versions: ${versions}"
+          echo "versions=${versions}" >> "${GITHUB_OUTPUT}"
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [extract-macos-sdk]
+    needs: [extract-macos-sdk, go-versions]
     strategy:
       matrix:
-        go:
-          - "1.25"
-          - "1.26"
+        go: ${{ fromJSON(needs.go-versions.outputs.versions) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/cmd/builder-bumper/main.go
+++ b/cmd/builder-bumper/main.go
@@ -312,8 +312,9 @@ func replaceMajor(old, current, next *goVersion) error {
 		return fmt.Errorf("failed to create new version directory: %w", err)
 	}
 
-	// Update CircleCI.
-	err = replace(".github/workflows/ci.yml",
+	// Update the CI build matrix. It lives outside .github/workflows/ because
+	// the workflow GITHUB_TOKEN can not push changes to workflow files.
+	err = replace(".ci-versions.yml",
 		[]func(string) (string, error){
 			majorVersionReplacer("", current, next),
 			majorVersionReplacer("", old, current),


### PR DESCRIPTION
The bumper used to rewrite .github/workflows/ci.yml on major bumps, which the workflow GITHUB_TOKEN can not push: there is no 'workflows' permission for it, which is why the 1.27 bump failed to push. Move the build matrix to .ci-versions.yml, a plain data file the bumper maintains, and read it from CI.